### PR TITLE
Fix `throw-ex` on `:cljs` branch

### DIFF
--- a/src/venia/exception.cljc
+++ b/src/venia/exception.cljc
@@ -8,4 +8,4 @@
 
 #?(:cljs (defmethod throw-ex :venia/spec-validation
            [data]
-           (throw (Error. (str "Invalid query data " data)))))
+           (throw (js/Error. (str "Invalid query data " data)))))


### PR DESCRIPTION
This is causing compilation errors and doesn't work the way it was.