### PR TITLE
`nil` should be serialized to `null`

### DIFF
--- a/src/venia/core.cljc
+++ b/src/venia/core.cljc
@@ -15,7 +15,7 @@
 
 #?(:clj (extend-protocol ArgumentFormatter
           nil
-          (arg->str [arg] "")
+          (arg->str [arg] "null")
           String
           (arg->str [arg] (str "\"" arg "\""))
           IPersistentMap
@@ -29,7 +29,7 @@
 
 #?(:cljs (extend-protocol ArgumentFormatter
            nil
-           (arg->str [arg] "")
+           (arg->str [arg] "null")
            string
            (arg->str [arg] (str "\"" arg "\""))
            PersistentArrayMap

--- a/test/venia/core_test.cljc
+++ b/test/venia/core_test.cljc
@@ -5,9 +5,10 @@
             [clojure.test :refer :all])))
 
 (deftest ArgumentFormatter-test
-  (is (= "" (v/arg->str nil)))
+  (is (= "null" (v/arg->str nil)))
   (is (= "\"human\"" (v/arg->str "human")))
   (is (= "{id:1}" (v/arg->str {:id 1})))
+  (is (= "{id:null}" (v/arg->str {:id nil})))
   (is (= "[1,2,3]" (v/arg->str [1 2 3])))
   (is (= "[1,{id:1},\"human\"]" (v/arg->str [1 {:id 1} "human"])))
   (is (= "\"human\"" (v/arg->str :human)))
@@ -17,6 +18,7 @@
 (deftest arguments->str-test
   (is (= "" (v/arguments->str {})))
   (is (= "id:1" (v/arguments->str {:id 1})))
+  (is (= "id:null" (v/arguments->str {:id nil})))
   (is (= "id:1,type:\"human\"" (v/arguments->str {:id 1 :type "human"})))
   (is (= "id:1,vector:[1,2,3]" (v/arguments->str {:id 1 :vector [1 2 3]}))))
 


### PR DESCRIPTION
Currently the value just is serialized to nothing and the generated query becomes invalid.