### PR TITLE
Bump clojure dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,8 @@
   :url "https://github.com/Vincit/venia"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha16" :scope "provided"]
-                 [org.clojure/clojurescript "1.9.521" :scope "provided"]]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17" :scope "provided"]
+                 [org.clojure/clojurescript "1.9.562" :scope "provided"]]
   :plugins [[lein-doo "0.1.7"]]
   :clean-targets ^{:protect false} ["resources" "target"]
   :aliases {"test" ["do" "test" ["doo" "once" "phantom" "test"]]}

--- a/src/venia/spec.cljc
+++ b/src/venia/spec.cljc
@@ -1,6 +1,6 @@
 (ns venia.spec
   (:require #?(:clj [clojure.spec.alpha :as s]
-               :cljs [cljs.spec :as s])
+               :cljs [cljs.spec.alpha :as s])
                     [venia.exception :as ex]))
 
 (s/def :venia/query-name keyword?)

--- a/src/venia/spec.cljc
+++ b/src/venia/spec.cljc
@@ -24,13 +24,10 @@
 (s/def :venia/query-def (s/coll-of (s/or :venia/query-vector (s/coll-of :venia/query)
                                          :venia/query-map (s/coll-of :venia/advanced-query))
                                    :min-count 1))
-(defn- invalid? [data]
-  (= #?(:clj  :clojure.spec.alpha/invalid
-        :cljs :cljs.spec/invalid) data))
 
 (defn query->spec [query]
   (let [conformed (s/conform :venia/query-def query)]
-    (if (invalid? conformed)
+    (if (= ::s/invalid conformed)
       (ex/throw-ex {:venia/ex-type    :venia/spec-validation
                     :venia/ex-explain (s/explain :venia/query-def query)})
       conformed)))


### PR DESCRIPTION
Update to newest versions (to date) of both Clojure and ClojureScript. `cljs.spec` namespace was renamed, so this update is required to not hold clients from upgrade themselves.