### PR TITLE
Add args only case for nested fields

### DIFF
--- a/src/venia/core.cljc
+++ b/src/venia/core.cljc
@@ -65,7 +65,9 @@
                                         (str "(" (arguments->str (:args value)) ")"))
                                       "{"
                                       (fields->str (:venia/nested-field-children value))
-                                      "}")))
+                                      "}")
+             :venia/nested-field-arg-only (str (name (:venia/nested-field-root value))
+                                            (str "(" (arguments->str (:args value)) ")"))))
          (interpose ",")
          (apply str))))
 

--- a/src/venia/spec.cljc
+++ b/src/venia/spec.cljc
@@ -17,11 +17,17 @@
   (second (s/conform spec x)))
 
 (s/def :venia/query-name keyword?)
-(s/def :venia/fields (s/conformer #(or-conformer % (s/or :fields (s/coll-of (s/or :venia/field keyword?
-                                                                                  :venia/nested-field (s/cat :venia/nested-field-root keyword?
-                                                                                                             :args (s/? :venia/args)
-                                                                                                             :venia/nested-field-children :venia/fields)))
-                                                         :fragment fragment-keyword?))))
+(s/def :venia/fields
+  (s/conformer
+    #(or-conformer %
+                   (s/or :fields
+                         (s/coll-of (s/or :venia/field keyword?
+                                          :venia/nested-field-arg-only (s/cat :venia/nested-field-root keyword?
+                                                                         :args :venia/args)
+                                          :venia/nested-field (s/cat :venia/nested-field-root keyword?
+                                                                :args (s/? :venia/args)
+                                                                :venia/nested-field-children :venia/fields)))
+                         :fragment fragment-keyword?))))
 
 (s/def :venia/args (s/keys :opt []))
 (s/def :query/data (s/cat :query :venia/query-name :args (s/? :venia/args) :fields :venia/fields))

--- a/test/venia/core_test.cljc
+++ b/test/venia/core_test.cljc
@@ -55,6 +55,11 @@
           query-str "{employee(id:1,active:true){name,address,friends{name,email}}}"]
       (is (= query-str (v/graphql-query data)))))
 
+  (testing "Should create a valid graphql string using params on nested fields that doesnt't have nested fields."
+    (let [data {:venia/queries [[:employee {:id 1 :active true} [:name :address [:boss_name {:id 1}]]]]}
+          query-str "{employee(id:1,active:true){name,address,boss_name(id:1)}}"]
+      (is (= query-str (v/graphql-query data)))))
+
   (testing "Should create a valid graphql string using params on nested fields."
     (let [data {:venia/queries [[:employee {:id 1 :active true} [:name :address [:friends {:id 1} [:name :email]]]]]}
           query-str "{employee(id:1,active:true){name,address,friends(id:1){name,email}}}"]


### PR DESCRIPTION
Allows the creation of queries like `{employee(id:1,active:true){name,address,boss_name(id:1)}}` where boss_name is a field with no children.