### PR TITLE
arg->str for List, LazySeq and IndexedSeq

### DIFF
--- a/src/venia/core.cljc
+++ b/src/venia/core.cljc
@@ -19,6 +19,11 @@
        flatten
        (apply str)))
 
+(defn sequential->str
+  "Given something that is sequential format it to be like a JSON array."
+  [arg]
+  (str "[" (apply str (interpose "," (map arg->str arg))) "]"))
+
 #?(:clj (extend-protocol ArgumentFormatter
           nil
           (arg->str [arg] "null")
@@ -43,7 +48,13 @@
            PersistentHashMap
            (arg->str [arg] (str "{" (arguments->str arg) "}"))
            PersistentVector
-           (arg->str [arg] (str "[" (apply str (interpose "," (map arg->str arg))) "]"))
+           (arg->str [arg] (sequential->str arg))
+           IndexedSeq
+           (arg->str [arg] (sequential->str arg))
+           LazySeq
+           (arg->str [arg] (sequential->str arg))
+           List
+           (arg->str [arg] (sequential->str arg))
            Keyword
            (arg->str [arg] (name arg))
            number

--- a/test/venia/core_test.cljc
+++ b/test/venia/core_test.cljc
@@ -23,7 +23,13 @@
            (-> output
                (string/replace #"^.|.$" "")
                (string/split #",")
-               (set))))))
+               (set)))))
+  ;; List in cljs
+  (is (= "[1,2,3]" (v/arg->str '(1 2 3))))
+  ;; IndexedSeq in cljs
+  (is (= "[1,2,3]" (v/arg->str (seq [1 2 3]))))
+  ;; LazySeq in cljs
+  (is (= "[1,2,3]" (v/arg->str (map :x [{:x 1} {:x 2} {:x 3}])))))
 
 (deftest arguments->str-test
   (is (= "" (v/arguments->str {})))


### PR DESCRIPTION
For handling arg->str in cljs.   Generate '[' and ']' instead of '(' and ')'.