### PR TITLE
Add list support for :variable/type

### DIFF
--- a/src/venia/core.cljc
+++ b/src/venia/core.cljc
@@ -103,13 +103,22 @@
          (interpose ",")
          (apply str))))
 
+(defn- variable-type->str
+  "Convert a spec conformed variable type to a string."
+  [[tag type]]
+  (case tag
+    :list
+    (str "[" (-> type first name) "]")
+    :type
+    (name type)))
+
 (defn variables->str
   "Given a vector of variable maps, formats them and concatenates to string.
 
   E.g. (variables->str [{:variable/name \"id\" :variable/type :Int}]) => \"$id: Int\""
   [variables]
   (->> (for [{var-name :variable/name var-type :variable/type var-default :variable/default} variables]
-         (str "$" var-name ":" (name var-type) (when var-default (str "=" (arg->str var-default)))))
+         (str "$" var-name ":" (variable-type->str var-type) (when var-default (str "=" (arg->str var-default)))))
        (interpose ",")
        (apply str)))
 

--- a/src/venia/spec.cljc
+++ b/src/venia/spec.cljc
@@ -148,7 +148,10 @@
 (s/def :venia/operation (s/keys :req [:operation/type :operation/name]))
 
 (s/def :variable/name string?)
-(s/def :variable/type keyword?)
+
+(s/def :variable/type
+  (s/or :type keyword? :list (s/coll-of keyword? :kind vector? :count 1)))
+
 (s/def :query/variable (s/keys :req [:variable/name :variable/type]
                                :opt [:variable/default]))
 (s/def :venia/variables (s/coll-of :query/variable :min-count 1))

--- a/test/venia/core_test.cljc
+++ b/test/venia/core_test.cljc
@@ -50,19 +50,21 @@
 
 (deftest variables->str-test
   (is (= "$id:Int" (v/variables->str [{:variable/name "id"
-                                       :variable/type :Int}])))
+                                       :variable/type [:type :Int]}])))
+  (is (= "$ids:[Int!]" (v/variables->str [{:variable/name "ids"
+                                           :variable/type [:list [:Int!]]}])))
   (is (= "$id:Int=2" (v/variables->str [{:variable/name    "id"
-                                         :variable/type    :Int
+                                         :variable/type    [:type :Int]
                                          :variable/default 2}])))
   (is (= "$id:Int,$name:String" (v/variables->str [{:variable/name "id"
-                                                    :variable/type :Int}
+                                                    :variable/type [:type :Int]}
                                                    {:variable/name "name"
-                                                    :variable/type :String}])))
+                                                    :variable/type [:type :String]}])))
   (is (= "$id:Int=1,$name:String=\"my-name\"" (v/variables->str [{:variable/name    "id"
-                                                                  :variable/type    :Int
+                                                                  :variable/type    [:type :Int]
                                                                   :variable/default 1}
                                                                  {:variable/name    "name"
-                                                                  :variable/type    :String
+                                                                  :variable/type    [:type :String]
                                                                   :variable/default "my-name"}])))
   (is (= "" (v/variables->str nil)))
   (is (= "" (v/variables->str []))))
@@ -280,3 +282,15 @@
           query-str (str "mutation AddProjectToEmployee($id:Int!,$project:ProjectNameInput!){addProject(employeeId:$id,project:$project){allocation,name}}")
           result (v/graphql-query data)]
       (is (= query-str result)))))
+
+(deftest test-query-with-list-variables
+  (is (= (v/graphql-query
+          {:venia/operation
+           {:operation/type :query
+            :operation/name "MyQuery"}
+           :venia/queries
+           [[:node {:ids :$ids} [:id]]]
+           :venia/variables
+           [{:variable/name "ids"
+             :variable/type [:ID!]}]})
+         "query MyQuery($ids:[ID!]){node(ids:$ids){id}}")))

--- a/test/venia/spec_test.cljc
+++ b/test/venia/spec_test.cljc
@@ -112,9 +112,9 @@
     (is (= [:venia/query-def {:venia/operation {:operation/type :query
                                                 :operation/name "employeeQuery"}
                               :venia/variables [{:variable/name "id"
-                                                 :variable/type :Int}
+                                                 :variable/type [:type :Int]}
                                                 {:variable/name "name"
-                                                 :variable/type :String}]
+                                                 :variable/type [:type :String]}]
                               :venia/fragments [{:fragment/name   "comparisonFields"
                                                  :fragment/type   :Worker
                                                  :fragment/fields [[:venia/field :name] [:venia/field :address]


### PR DESCRIPTION
Hello @macluck,

I would like to use list types in my GraphQL variables, but it looks like venia doesn't support this yet. This PR adds support for this.

Would you like to merge this?

Roman