### PR TITLE
escape special chars in strings

### DIFF
--- a/src/venia/core.cljc
+++ b/src/venia/core.cljc
@@ -25,11 +25,22 @@
   [arg]
   (str "[" (apply str (interpose "," (map arg->str arg))) "]"))
 
+(defn encode-string
+  "Handles escaping special characters."
+  [arg]
+  (str "\"" (str/escape arg {\"         "\\\""
+                             \\         "\\\\"
+                             \newline   "\\n"
+                             \return    "\\r"
+                             \tab       "\\t"
+                             \formfeed  "\\f"
+                             \backspace "\\b"}) "\""))
+
 #?(:clj (extend-protocol ArgumentFormatter
           nil
           (arg->str [arg] "null")
           String
-          (arg->str [arg] (str "\"" arg "\""))
+          (arg->str [arg] (encode-string arg))
           IPersistentMap
           (arg->str [arg] (str "{" (arguments->str arg) "}"))
           IPersistentCollection
@@ -43,7 +54,7 @@
            nil
            (arg->str [arg] "null")
            string
-           (arg->str [arg] (str "\"" arg "\""))
+           (arg->str [arg] (encode-string arg))
            PersistentArrayMap
            (arg->str [arg] (str "{" (arguments->str arg) "}"))
            PersistentHashMap

--- a/test/venia/core_test.cljc
+++ b/test/venia/core_test.cljc
@@ -8,6 +8,13 @@
 (deftest ArgumentFormatter-test
   (is (= "null" (v/arg->str nil)))
   (is (= "\"human\"" (v/arg->str "human")))
+  (is (= "\"\\\"human\\\"\"" (v/arg->str "\"human\"")))
+  (is (= "\"What's a \\\"human\\\"?\"" (v/arg->str "What's a \"human\"?")))
+  (is (= "\"hu\\nman\"" (v/arg->str (str "hu" \newline "man"))))
+  (is (= "\"hu\\rman\"" (v/arg->str (str "hu" \return "man"))))
+  (is (= "\"hu\\tman\"" (v/arg->str (str "hu" \tab "man"))))
+  (is (= "\"hu\\fman\"" (v/arg->str (str "hu" \formfeed "man"))))
+  (is (= "\"hu\\bman\"" (v/arg->str (str "hu" \backspace "man"))))
   (is (= "{id:1}" (v/arg->str {:id 1})))
   (is (= "{id:null}" (v/arg->str {:id nil})))
   (is (= "[1,2,3]" (v/arg->str [1 2 3])))


### PR DESCRIPTION
Strings containing various special chars such as `\"`,  `\\`, `\newline`, `\return`, `\tab`, `\backspace` and `\formfeed` need to be escaped otherwise graphql servers can't parse the query.  This addresses escaping those characters.  This change was tested against a server running [Lacinia](https://github.com/walmartlabs/lacinia).